### PR TITLE
feat: keyExtractor for custom svelte loop key

### DIFF
--- a/src/Slidy.svelte
+++ b/src/Slidy.svelte
@@ -3,6 +3,7 @@
 	import * as action from "./actions.js";
 
 	export let slides = [],
+		keyExtractor=(item,i)=>item.id||i,
 		wrap = {
 			id: null,
 			width: "100%",
@@ -380,7 +381,7 @@
 
 	<ul class="slidy-ul" on:contextmenu={() => (isdrag = false)} style={move()}>
 		{#if slides}
-			{#each slides as item, i (item.id)}
+			{#each slides as item, i (keyExtractor(item,i))}
 				<li
 					bind:this={nodes[i]}
 					data-id={i}
@@ -395,7 +396,7 @@
 					{#if slidyinit}
 						<slot {item}>
 							{#if slide.backimg === false}
-								<img alt={item.id} src={item[slide.imgsrckey]} width={item.width} height={item.height} />
+								<img alt={keyExtractor(item,i)} src={item[slide.imgsrckey]} width={item.width} height={item.height} />
 							{/if}
 						</slot>
 					{/if}


### PR DESCRIPTION
This PR related #18 
On newer version of svelte, without this keyExtractor svelte will fail to render if there is no id key due to duplicate each key (item.id will be undefined)
This will add keyExtractor props as function to customize svelte loop key. The default return value is item.id or will fallback to array index if there is no id key.
usage:
``` svelte
<Slidy keyExtractor={(item,index)=>item.id+index+uid()} />
```
or
``` svelte
<Slidy keyExtractor={(item)=>item.id.toString()} />
```